### PR TITLE
Remove state from websocket messages

### DIFF
--- a/jellyfish/server_notifications.proto
+++ b/jellyfish/server_notifications.proto
@@ -33,55 +33,6 @@ message ServerMessage {
     string token = 1;
   }
 
-  message RoomState {
-    message Config {
-      enum Codec {
-        CODEC_UNSPECIFIED = 0;
-        CODEC_H264 = 1;
-        CODEC_VP8 = 2;
-      }
-
-      uint32 max_peers = 1;
-      Codec video_codec = 2;
-    }
-
-    message Peer {
-      enum Type {
-        TYPE_UNSPECIFIED = 0;
-        TYPE_WEBRTC = 1;
-      }
-
-      enum Status {
-        STATUS_UNSPECIFIED = 0;
-        STATUS_CONNECTED = 1;
-        STATUS_DISCONNECTED = 2;
-      }
-
-      string id = 1;
-      Type type = 2;
-      Status status = 3;
-    }
-
-    message Component {
-      message Hls {
-        bool playable = 1;
-      }
-
-      message Rtsp {}
-
-      string id = 1;
-      oneof component {
-        Hls hls = 2;
-        Rtsp rtsp = 3;
-      }
-    }
-
-    string id = 1;
-    Config config = 2;
-    repeated Peer peers = 3;
-    repeated Component components = 4;
-  }
-
   enum EventType {
     EVENT_TYPE_UNSPECIFIED = 0;
     EVENT_TYPE_SERVER_NOTIFICATION = 1;
@@ -108,20 +59,6 @@ message ServerMessage {
     string metrics = 1;
   }
 
-  message RoomStateRequest {
-    string room_id = 1;
-  }
-
-  message RoomNotFound {
-    string room_id = 1;
-  }
-
-  message GetRoomIds {}
-
-  message RoomIds {
-    repeated string ids = 1;
-  }
-
   message HlsPlayable {
     string room_id = 1;
     string component_id = 2;
@@ -141,10 +78,5 @@ message ServerMessage {
     RoomDeleted room_deleted = 11;
     MetricsReport metrics_report = 12;
     HlsPlayable hls_playable = 13;
-    RoomStateRequest room_state_request = 14;
-    RoomState room_state = 15;
-    RoomNotFound room_not_found = 16;
-    GetRoomIds get_room_ids = 17;
-    RoomIds room_ids = 18;
   }
 }

--- a/jellyfish/server_notifications.proto
+++ b/jellyfish/server_notifications.proto
@@ -79,20 +79,18 @@ message ServerMessage {
     repeated Component components = 4;
   }
 
+  enum EventType {
+    EVENT_TYPE_UNSPECIFIED = 0;
+    EVENT_TYPE_SERVER_NOTIFICATION = 1;
+    EVENT_TYPE_METRICS = 2;
+  }
+
   message SubscribeRequest {
-    message ServerNotification {}
-
-    message Metrics {}
-
-    string id = 1;
-    oneof event_type {
-      ServerNotification server_notification = 2;
-      Metrics metrics = 3;
-    }
+    EventType event_type = 1;
   }
 
   message SubscribeResponse {
-    string id = 1;
+    EventType event_type = 1;
   }
 
   message RoomCreated {

--- a/jellyfish/server_notifications.proto
+++ b/jellyfish/server_notifications.proto
@@ -92,14 +92,7 @@ message ServerMessage {
   }
 
   message SubscribeResponse {
-    message RoomStates {
-      repeated RoomState rooms = 1;
-    }
-
     string id = 1;
-    oneof content {
-      RoomStates room_states = 2;
-    }
   }
 
   message RoomCreated {
@@ -122,6 +115,12 @@ message ServerMessage {
     string room_id = 1;
   }
 
+  message GetRoomIds {}
+
+  message RoomIds {
+    repeated string ids = 1;
+  }
+
   oneof content {
     RoomCrashed room_crashed = 1;
     PeerConnected peer_connected = 2;
@@ -138,5 +137,7 @@ message ServerMessage {
     RoomStateRequest room_state_request = 13;
     RoomState room_state = 14;
     RoomNotFound room_not_found = 15;
+    GetRoomIds get_room_ids = 16;
+    RoomIds room_ids = 17;
   }
 }

--- a/jellyfish/server_notifications.proto
+++ b/jellyfish/server_notifications.proto
@@ -33,18 +33,54 @@ message ServerMessage {
     string token = 1;
   }
 
-  message SubscribeRequest {
-    message ServerNotification {
-      enum Option {
-        OPTION_UNSPECIFIED = 0;
-        OPTION_ALL = 1;
+  message RoomState {
+    message Config {
+      enum Codec {
+        CODEC_UNSPECIFIED = 0;
+        CODEC_H264 = 1;
+        CODEC_VP8 = 2;
       }
 
-      oneof room_id {
-        string id = 1;
-        Option option = 2;
-      }
+      uint32 max_peers = 1;
+      Codec video_codec = 2;
     }
+
+    message Peer {
+      enum Type {
+        TYPE_UNSPECIFIED = 0;
+        TYPE_WEBRTC = 1;
+      }
+
+      enum Status {
+        STATUS_UNSPECIFIED = 0;
+        STATUS_CONNECTED = 1;
+        STATUS_DISCONNECTED = 2;
+      }
+
+      string id = 1;
+      Type type = 2;
+      Status status = 3;
+    }
+
+    message Component {
+      enum Type {
+        TYPE_UNSPECIFIED = 0;
+        TYPE_HLS = 1;
+        TYPE_RTSP = 2;
+      }
+
+      string id = 1;
+      Type type = 2;
+    }
+
+    string id = 1;
+    Config config = 2;
+    repeated Peer peers = 3;
+    repeated Component components = 4;
+  }
+
+  message SubscribeRequest {
+    message ServerNotification {}
 
     message Metrics {}
 
@@ -56,65 +92,13 @@ message ServerMessage {
   }
 
   message SubscribeResponse {
-    message RoomState {
-      message Config {
-        enum Codec {
-          CODEC_UNSPECIFIED = 0;
-          CODEC_H264 = 1;
-          CODEC_VP8 = 2;
-        }
-
-        uint32 max_peers = 1;
-        Codec video_codec = 2;
-      }
-
-      message Peer {
-        enum Type {
-          TYPE_UNSPECIFIED = 0;
-          TYPE_WEBRTC = 1;
-        }
-
-        enum Status {
-          STATUS_UNSPECIFIED = 0;
-          STATUS_CONNECTED = 1;
-          STATUS_DISCONNECTED = 2;
-        }
-
-        string id = 1;
-        Type type = 2;
-        Status status = 3;
-      }
-
-      message Component {
-        enum Type {
-          TYPE_UNSPECIFIED = 0;
-          TYPE_HLS = 1;
-          TYPE_RTSP = 2;
-        }
-
-        string id = 1;
-        Type type = 2;
-      }
-
-      string id = 1;
-      Config config = 2;
-      repeated Peer peers = 3;
-      repeated Component components = 4;
-    }
-
-    message RoomsState {
+    message RoomStates {
       repeated RoomState rooms = 1;
-    }
-
-    message RoomNotFound {
-      string id = 1;
     }
 
     string id = 1;
     oneof content {
-      RoomState room_state = 2;
-      RoomsState rooms_state = 3;
-      RoomNotFound room_not_found = 4;
+      RoomStates room_states = 2;
     }
   }
 
@@ -130,6 +114,14 @@ message ServerMessage {
     string metrics = 1;
   }
 
+  message RoomStateRequest {
+    string room_id = 1;
+  }
+
+  message RoomNotFound {
+    string room_id = 1;
+  }
+
   oneof content {
     RoomCrashed room_crashed = 1;
     PeerConnected peer_connected = 2;
@@ -143,5 +135,8 @@ message ServerMessage {
     RoomCreated room_created = 10;
     RoomDeleted room_deleted = 11;
     MetricsReport metrics_report = 12;
+    RoomStateRequest room_state_request = 13;
+    RoomState room_state = 14;
+    RoomNotFound room_not_found = 15;
   }
 }


### PR DESCRIPTION
* remove `room_id` from `ServerNotification` - from now on only allow subscribing for all rooms
* remove `RoomState` from server messages - the state is only available via REST api

ref: https://github.com/jellyfish-dev/jellyfish/pull/60
https://github.com/jellyfish-dev/elixir_server_sdk/pull/25